### PR TITLE
Changed error format string to use %d for integer values

### DIFF
--- a/src/net/rtp/datapacket_test.go
+++ b/src/net/rtp/datapacket_test.go
@@ -83,7 +83,7 @@ func csrcTest(rp *DataPacket, t *testing.T, csrc []uint32, run int) (result bool
 	csrcTmp := rp.CsrcList()
 	for i, v := range csrcTmp {
 		if v != csrc[i] {
-			t.Error(fmt.Sprintf("CSRC-%d check failed at %i. Expected: %x, got: %x\n", run, i, csrc[i], csrcTmp[i]))
+			t.Error(fmt.Sprintf("CSRC-%d check failed at %d. Expected: %x, got: %x\n", run, i, csrc[i], csrcTmp[i]))
 			return
 		}
 	}
@@ -96,7 +96,7 @@ func csrcTest(rp *DataPacket, t *testing.T, csrc []uint32, run int) (result bool
 	pay := rp.Payload()
 	for i, v := range payload {
 		if v != pay[i] {
-			t.Error(fmt.Sprintf("Payload-CSRC-%d check failed at %i. Expected: %x, got: %x\n", run, i, payload[i], pay[i]))
+			t.Error(fmt.Sprintf("Payload-CSRC-%d check failed at %d. Expected: %x, got: %x\n", run, i, payload[i], pay[i]))
 			return
 		}
 	}
@@ -122,7 +122,7 @@ func extTest(rp *DataPacket, t *testing.T, ext []byte, run int) (result bool) {
 	extTmp := rp.Extension()
 	for i, v := range extTmp {
 		if v != ext[i] {
-			t.Error(fmt.Sprintf("EXT-%d check failed at %i. Expected: %x, got: %x\n", run, i, ext[i], extTmp[i]))
+			t.Error(fmt.Sprintf("EXT-%d check failed at %d. Expected: %x, got: %x\n", run, i, ext[i], extTmp[i]))
 			return
 		}
 	}
@@ -135,7 +135,7 @@ func extTest(rp *DataPacket, t *testing.T, ext []byte, run int) (result bool) {
 	pay := rp.Payload()
 	for i, v := range payload {
 		if v != pay[i] {
-			t.Error(fmt.Sprintf("Payload-EXT-%d check failed at %i. Expected: %x, got: %x\n", run, i, payload[i], pay[i]))
+			t.Error(fmt.Sprintf("Payload-EXT-%d check failed at %d. Expected: %x, got: %x\n", run, i, payload[i], pay[i]))
 			return
 		}
 	}
@@ -202,7 +202,7 @@ func rtpPacket(t *testing.T) {
 	}
 	for i, v := range payload {
 		if v != pay[i] {
-			t.Error(fmt.Sprintf("Payload check failed at %i. Expected: %x, got: %x\n", i, payload[i], pay[i]))
+			t.Error(fmt.Sprintf("Payload check failed at %d. Expected: %x, got: %x\n", i, payload[i], pay[i]))
 			return
 		}
 	}
@@ -254,7 +254,7 @@ func rtpPacket(t *testing.T) {
 	}
 	for i, v := range payload {
 		if v != pay[i] {
-			t.Error(fmt.Sprintf("Payload check failed at %i. Expected: %x, got: %x\n", i, payload[i], pay[i]))
+			t.Error(fmt.Sprintf("Payload check failed at %d. Expected: %x, got: %x\n", i, payload[i], pay[i]))
 			return
 		}
 	}


### PR DESCRIPTION
Hi @wernerd ,

Thank you for merging my previous PR (about `gofmt`).

This one changes string formatting to use `%d` instead of `%i` in tests to mitigate the following error I received when running `go test ./...`)
```
src/net/rtp/datapacket_test.go:86: Sprintf format %i has unknown verb i
```
Here's a reproducible example in go playground:
https://play.golang.org/p/nUc4EQOxyAR

Thanks!