### PR TITLE
Adds DataPacket.Clone() method

### DIFF
--- a/src/net/rtp/datapacket_test.go
+++ b/src/net/rtp/datapacket_test.go
@@ -19,6 +19,7 @@
 package rtp
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"net"
@@ -351,4 +352,37 @@ func TestRtpPacket(t *testing.T) {
 	rtpPacket(t)
 	ntpCheck(t)
 	//    intervalCheck(t)
+}
+
+func assertEqual(t *testing.T, lhs, rhs interface{}, message string) {
+	if lhs != rhs {
+		t.Errorf("%s: %v != %v", message, lhs, rhs)
+		t.FailNow()
+	}
+}
+
+func assertBytesEqual(t *testing.T, lhs, rhs []byte, message string) {
+	if !bytes.Equal(lhs, rhs) {
+		t.Errorf("%s: %v != %v", message, lhs, rhs)
+		t.FailNow()
+	}
+}
+
+func TestCloneDataPacket(t *testing.T) {
+	packet := newTestDataPacket()
+	packet.SetPayload([]byte{1, 2, 3, 4})
+	clone := packet.Clone()
+
+	assertEqual(t, clone.IsValid(), packet.IsValid(), "clone is invalid")
+	assertEqual(t, clone.Padding(), packet.Padding(), "paddings mismatch")
+	assertEqual(t, clone.Marker(), packet.Marker(), "marker mismatch")
+	assertEqual(t, clone.CsrcCount(), packet.CsrcCount(), "ssrc count mismatch")
+	assertEqual(t, clone.Sequence(), packet.Sequence(), "sequence mismatch")
+	assertBytesEqual(t, clone.Extension(), packet.Extension(), "extension mismatch")
+	assertBytesEqual(t, clone.Payload(), packet.Payload(), "extension mismatch")
+
+	packet.FreePacket()
+	assertEqual(t, packet.IsValid(), false, fmt.Sprintf("packet %+v should not be valid", packet))
+	assertEqual(t, clone.IsValid(), true, fmt.Sprintf("packet %+v should be valid", packet))
+	assertBytesEqual(t, clone.Payload(), []byte{1, 2, 3, 4}, "extension mismatch")
 }

--- a/src/net/rtp/datapacket_test.go
+++ b/src/net/rtp/datapacket_test.go
@@ -146,8 +146,7 @@ func extTest(rp *DataPacket, t *testing.T, ext []byte, run int) (result bool) {
 	return
 }
 
-func rtpPacket(t *testing.T) {
-
+func newTestDataPacket() *DataPacket {
 	// Prepare some data to create a RP session, RTP stream and then RTP packets
 	port := 5220
 	local, _ := net.ResolveIPAddr("ip", "127.0.0.1")
@@ -172,7 +171,12 @@ func rtpPacket(t *testing.T) {
 	// The method initializes the RTP packet with SSRC, sequence number, and RTP version number.
 	// If the payload type was set with the RTP stream then the payload type is also set in
 	// the RTP packet
-	rp := rsLocal.NewDataPacket(160)
+	return rsLocal.NewDataPacket(160)
+}
+
+func rtpPacket(t *testing.T) {
+
+	rp := newTestDataPacket()
 	rp.SetTimestamp(0xF0E0D0C0)
 
 	if !headerCheck(rp, t) {

--- a/src/net/rtp/packets.go
+++ b/src/net/rtp/packets.go
@@ -163,6 +163,22 @@ func (rp *DataPacket) FreePacket() {
 	}
 }
 
+// Clone returns an exact clone of the original packet
+func (rp *DataPacket) Clone() *DataPacket {
+	clone := &DataPacket{
+		RawPacket: RawPacket{
+			inUse:    rp.InUse(),
+			padTo:    rp.padTo,
+			isFree:   rp.isFree,
+			fromAddr: rp.fromAddr,
+			buffer:   make([]byte, len(rp.buffer), cap(rp.buffer)),
+		},
+		payloadLength: rp.payloadLength,
+	}
+	copy(clone.buffer, rp.buffer)
+	return clone
+}
+
 // CsrcCount return the number of CSRC values in this packet
 func (rp *DataPacket) CsrcCount() uint8 {
 	return rp.buffer[0] & ccMask


### PR DESCRIPTION
This PR adds DataPacket.Clone() method so packets could be passed easily between goroutines.

The use-case i had in mind is when a packet is passed to a goroutine and is freed later on so second goroutine panics.

To fix this, a clone of a packed could passed instead.

Please let me know what you think.

Thank you!
