### PR TITLE
Copy raw RTP data, customizable settings

### DIFF
--- a/src/net/rtp/packets.go
+++ b/src/net/rtp/packets.go
@@ -92,7 +92,12 @@ const (
 
 // nullArray is what it's names says: a long array filled with zeros.
 // used to clear (fill with zeros) arrays/slices inside a buffer by copying.
-var nullArray [1200]byte
+var nullArray = make([]byte, bufferSize)
+
+var bufferSize int = defaultBufferSize
+
+// SetBufferSize sets buffer size
+func SetBufferSize(v int) { bufferSize = v }
 
 // RawPacket is plain buffer with some metadata
 type RawPacket struct {
@@ -159,7 +164,7 @@ func newDataPacket() (rp *DataPacket) {
 	case rp = <-freeListRtp: // Got one; nothing more to do.
 	default:
 		rp = new(DataPacket) // None free, so allocate a new one.
-		rp.buffer = make([]byte, defaultBufferSize)
+		rp.buffer = make([]byte, bufferSize)
 	}
 	rp.buffer[0] = version2Bit // RTP: V = 2, P, X, CC = 0
 	rp.inUse = rtpHeaderLength
@@ -522,7 +527,7 @@ func newCtrlPacket() (rp *CtrlPacket, offset int) {
 	case rp = <-freeListRtcp: // Got one; nothing more to do.
 	default:
 		rp = new(CtrlPacket) // None free, so allocate a new one.
-		rp.buffer = make([]byte, defaultBufferSize)
+		rp.buffer = make([]byte, bufferSize)
 	}
 	rp.buffer[0] = version2Bit // RTCP: V = 2, P, RC = 0
 	rp.inUse = rtcpHeaderLength

--- a/src/net/rtp/packets.go
+++ b/src/net/rtp/packets.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"sync"
 )
 
 const (
@@ -90,9 +91,13 @@ const (
 	reportBlockLen = 24
 )
 
-// nullArray is what it's names says: a long array filled with zeros.
-// used to clear (fill with zeros) arrays/slices inside a buffer by copying.
-var nullArray = make([]byte, bufferSize)
+var (
+	// nullArray is what it's names says: a long array filled with zeros.
+	// used to clear (fill with zeros) arrays/slices inside a buffer by copying.
+	nullArray []byte = nil
+
+	nullArrayInitOnce sync.Once
+)
 
 var bufferSize int = defaultBufferSize
 

--- a/src/net/rtp/packets.go
+++ b/src/net/rtp/packets.go
@@ -120,9 +120,32 @@ func (rp *RawPacket) InUse() int {
 	return rp.inUse
 }
 
+// SetIsFree sets isFree attr
+func (rp *RawPacket) SetIsFree(v bool) {
+	rp.isFree = v
+}
+
+// SetBuffer set buffer
+func (rp *RawPacket) SetBuffer(b []byte) {
+	rp.buffer = b
+}
+
+// SetInUse sets real buffer size
+func (raw *RawPacket) SetInUse(iu int) {
+	raw.inUse = iu
+}
+
 // *** RTP specific functions start here ***
 
 // DataPacket RTP packet type to define RTP specific functions
+//
+// if you want to copy incoming RTP packet as-is. For example
+// when you need to redirect RTP packet from WebRTC to plain RTP:
+//   pkt := rtp.DataPacket{}
+//   pkt.SetBuffer(buf.Bytes())
+//   pkt.SetInUse(buf.Len())
+//   pkt.SetIsFree(true)
+//   session.WriteData(&pkt)
 type DataPacket struct {
 	RawPacket
 	payloadLength int16

--- a/src/net/rtp/session.go
+++ b/src/net/rtp/session.go
@@ -168,8 +168,22 @@ func NewSession(tpw TransportWrite, tpr TransportRecv) *Session {
 //
 //   remote - the RTP address of the remote peer. The RTP data port number must be even.
 //
-func (rs *Session) AddRemote(remote *Address) (index uint32, err error) {
-	if (remote.DataPort & 0x1) == 0x1 {
+func (rs *Session) AddRemote(remote *Address) (uint32, error) {
+	return rs.addRemote(remote, true)
+}
+
+// AddRemoteNonStrict acts as AddRemote, but doesn't performs any
+// port number even/odd checks
+//
+// It is usefull when you pick 2 random ports via OS.
+// net.ResolveTCPAddr("tcp", "localhost:0") for example.
+// Random ports are not always even or odd.
+func (rs *Session) AddRemoteNonStrict(remote *Address) (uint32, error) {
+	return rs.addRemote(remote, false)
+}
+
+func (rs *Session) addRemote(remote *Address, strict bool) (index uint32, err error) {
+	if strict && (remote.DataPort&0x1) == 0x1 {
 		return 0, Error("RTP data port number is not an even number.")
 	}
 

--- a/src/net/rtp/session.go
+++ b/src/net/rtp/session.go
@@ -757,11 +757,15 @@ func (rs *Session) WriteData(rp *DataPacket) (n int, err error) {
 
 	// Check here if SRTP is enabled for the SSRC of the packet - a stream attribute
 	for _, remote := range rs.remotes {
-		_, err := rs.transportWrite.WriteDataTo(rp, remote)
+		written, err := rs.transportWrite.WriteDataTo(rp, remote)
+
 		if err != nil {
 			return 0, err
 		}
+
+		n = written
 	}
+
 	return n, nil
 }
 

--- a/src/net/rtp/sessionlocal.go
+++ b/src/net/rtp/sessionlocal.go
@@ -28,13 +28,13 @@ import (
 )
 
 const (
-	dataReceiveChanLen = 3
-	ctrlEventChanLen   = 3
+	defaultDataReceiveChanLen = 3
+	defaultCtrlEventChanLen   = 3
 )
 
 const (
-	maxNumberOutStreams = 5
-	maxNumberInStreams  = 30
+	defaultMaxNumberOutStreams = 5
+	defaultMaxNumberInStreams  = 30
 )
 
 // conflictAddr stores conflicting address detected during loop and collision check

--- a/src/net/rtp/stream.go
+++ b/src/net/rtp/stream.go
@@ -313,6 +313,10 @@ func (strm *SsrcStream) fillSenderInfo(info senderInfo) {
 
 // makeSdesChunk creates an SDES chunk at the current inUse position and returns offset that points after the chunk.
 func (strm *SsrcStream) makeSdesChunk(rc *CtrlPacket) (newOffset int) {
+	nullArrayInitOnce.Do(func() {
+		nullArray = make([]byte, bufferSize)
+	})
+
 	chunk, newOffset := rc.newSdesChunk(strm.sdesChunkLen)
 	copy(chunk, nullArray[:]) // fill with zeros before using
 	chunk.setSsrc(strm.ssrc)


### PR DESCRIPTION
1. AddRemoteNonStrict method to Session;
2. Make Session configurable with function arguments;
3. Allow copy RTP data via SetBuffer, SetInUse, SetIsFree methods;
4. Make buffer sizes customizable. Buffers are reused via sync.Pool;